### PR TITLE
DRTII-679 Add aria-label to table in the PaxTerminalOverview 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@drt/drt-react",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@drt/drt-react",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "-": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drt/drt-react",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "React components for DRT applications",
   "main": "dist/cjs/bundle.js",
   "module": "dist/esm/bundle.js",

--- a/src/components/Pax/PaxTerminalOverview/PaxTerminalOverview.tsx
+++ b/src/components/Pax/PaxTerminalOverview/PaxTerminalOverview.tsx
@@ -106,7 +106,7 @@ export const PaxTerminalOverview = ({
               }
               </Typography>
             </Stack>
-            <Table>
+            <Table aria-label={"Terminal " + terminal + " pax summary"}>
               <TableHead>
                 <TableRow>
                   <TableCell>Time</TableCell>


### PR DESCRIPTION
Added an aria label for the pax summary table for a given terminal on the main summary page - Related to the following PR and ticket 679.

(The reason this specific aria label for this table had to be added in this repo and not the art-v2 repo is due to the fact that this specific table is a react table that is exported and used in drt-v2 hence the aria label needed to be added here unlike the others tables that are all actioned within the drt-v2 repo itself)

PR - https://github.com/UKHomeOffice/drt-v2/pull/2390


